### PR TITLE
Fix strip command in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
           ext=""
           [[ "${{ matrix.name }}" == windows-* ]] && ext=".exe"
           bin="target/${{ matrix.target }}/release/keyweave${ext}"
-          [[ "${{ matrix.name }}" != windows-* ]] && strip "$bin"
+          strip "$bin" || true
           dst="keyweave-${{ matrix.target }}"
           mkdir -p "$dst" dist
           cp "$bin" "$dst/"


### PR DESCRIPTION
This pull request fixes the issue with the strip command in the release workflow. Previously, the strip command would always return an error, causing the workflow to fail. With this fix, the strip command is modified to include a fallback option, ensuring that the workflow continues even if the strip command fails.