### PR TITLE
Fix path to pattern in download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,7 +159,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: dist-*
+          pattern: dist-*
           merge-multiple: true
           path: dist
 


### PR DESCRIPTION
This pull request fixes the path to the pattern in the download step of the workflow. Previously, the pattern was set to "name: dist-*", which caused the download to fail. This PR updates the pattern to "pattern: dist-*" to ensure the correct files are downloaded.