### PR TITLE
Update keyweave crate version to 0.2.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "keyweave"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keyweave"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 authors = ["Bart van der Braak <bart@vanderbraak.nl>"]
 keywords = ["azure", "keyvault", "env"]


### PR DESCRIPTION
This pull request updates the keyweave crate version from 0.2.6 to 0.2.7. This update includes bug fixes and improvements to the Azure Key Vault integration.